### PR TITLE
Fixed sidebar input field bug for iPad portrait resolution

### DIFF
--- a/css/foundation.css
+++ b/css/foundation.css
@@ -1152,7 +1152,7 @@ div.slider-nav span.left {
 ---------------------------------------------------*/	
 
 
-	@media only screen and (max-width: 767px) {
+	@media only screen and (max-width: 768px) {
 		div.form-field input, div.form-field input.small, div.form-field input.medium, div.form-field input.large, div.form-field input.oversize, input.input-text, input.input-text.oversize, textarea,
 		form.nice div.form-field input, form.nice div.form-field input.oversize, form.nice input.input-text, form.nice input.input-text.oversize, form.nice textarea { display: block; width: 96%; padding: 6px 2% 4px; font-size: 18px; }
 		form.nice div.form-field input, form.nice div.form-field input.oversize, form.nice input.input-text, form.nice input.input-text.oversize, form.nice textarea { -webkit-border-radius: 2px; -moz-border-radius: 2px; border-radius: 2px; }


### PR DESCRIPTION
- when there is a form field (input, textarea) present in the sidebar on iPad portrait, a horizontal scrollbar will appear. (screen resolution 768x1024px)
- changing the forms media query to max-width: 768px fixes the issue.
