### PR TITLE
Add a link on blog's title

### DIFF
--- a/header.php
+++ b/header.php
@@ -73,7 +73,7 @@
 		<div class="row">
 			<header class="twelve columns" role="banner">
 				<div class="reverie-header">
-					<h1><?php bloginfo('name'); ?></h1>
+					<h1><a href="<?php bloginfo('url'); ?>"><?php bloginfo('name'); ?></a></h1>
 					<h4 class="subheader"><?php bloginfo('description'); ?></h4>
 				</div>
 				<nav role="navigation">

--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ License URI:        http://www.opensource.org/licenses/mit-license.php
 	div.reverie-header { margin: 0 0 30px 0; padding: 20px 0 0 0; border-bottom: solid 1px #ccc; }
 	div.reverie-header h1 { margin-bottom: 0; padding: 0; }
 	div.reverie-header h1 a { color: #181818; }
-	div.reverie-header h1 a:hover { color: #181818; }
+	div.reverie-header h1 a:hover { color: #2A85E8; }
 	div.reverie-header .subheader { margin-bottom: 9px; }
 	div.highlight { margin-bottom: 12px; }
 	img.beta { position: absolute; top: 0px; right: 0px; }


### PR DESCRIPTION
Hi milohuang,

I recently switch my wordpress blog on reverie, and forked your repository so as to make some modifications for my installation. The first thing I noticed while using reverie was that the blog's title isn't a link to the home page, which is pretty disturbing for an user. Commonly, wordpress templates introduces the title as a link to the home page.

So here is a modification I made so as to use the title of my blog as a link to the home page. Feel free to merge it in your repository if you find it useful for other users.
