### PR TITLE
fix 'Undefined variable' notice

### DIFF
--- a/lib/clean.php
+++ b/lib/clean.php
@@ -124,6 +124,7 @@ function reverie_scripts_and_styles() {
     // adding Foundation scripts file in the footer
     wp_register_script( 'reverie-js', get_template_directory_uri() . '/js/foundation.min.js', array( 'jquery' ), '', true );
     
+    global $is_IE;
     if ($is_IE) {
        wp_register_script ( 'html5shiv', "http://html5shiv.googlecode.com/svn/trunk/html5.js" , false, true);
     }


### PR DESCRIPTION
fix for Notice: Undefined variable: is_IE in \wp-content\themes\reverie-master\lib\clean.php on line 127
