### PR TITLE
Activates noConflict mode for jQuery, and enqueues jQuery's Migrate plug...

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -17,7 +17,9 @@
 <?php wp_footer(); ?>
 
 <script>
-	$(document).foundation();
+	(function($) {
+		$(document).foundation();
+	})(jQuery);
 </script>
 	
 </body>

--- a/js/jQuery-noConflict.js
+++ b/js/jQuery-noConflict.js
@@ -1,0 +1,1 @@
+jQuery.noConflict();

--- a/lib/clean.php
+++ b/lib/clean.php
@@ -120,6 +120,12 @@ function reverie_scripts_and_styles() {
     wp_deregister_script('jquery');
     // register Google jQuery
     wp_register_script('jquery', "http" . ($_SERVER['SERVER_PORT'] == 443 ? "s" : "") . "://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js", false, null, true);
+
+	// register jQuery noConflict mode script
+	wp_register_script( 'jquery-noconflict', get_stylesheet_directory_uri() . '/js/jQuery-noConflict.js', array('jquery'), '1.0', true );
+	
+	// register jQuery Migrate plugin (from code.jquery.com – "The minified production file is compressed and does not generate console warnings.")
+	wp_register_script( 'jquery-migrate', "http" . ($_SERVER['SERVER_PORT'] == 443 ? "s" : "") . "://code.jquery.com/jquery-migrate-1.1.1.min.js", array('jquery'), '1.1.1', true );
     
     // adding Foundation scripts file in the footer
     wp_register_script( 'reverie-js', get_template_directory_uri() . '/js/foundation.min.js', array( 'jquery' ), '', true );
@@ -137,6 +143,11 @@ function reverie_scripts_and_styles() {
     and your site will load faster.
     */
     wp_enqueue_script( 'jquery' );
+	
+	// enqueue jQuery noConflict mode script and Migrate plugin
+	wp_enqueue_script ('jquery-noconflict');
+	wp_enqueue_script ('jquery-migrate');
+	
     wp_enqueue_script( 'reverie-js' );
     wp_enqueue_script( 'html5shiv' );
 


### PR DESCRIPTION
...in for backwards compatibility. Instantiates foundation.js to comply with jQuery noConflict mode.

According to http://eamann.com/tech/dont-dequeue-wordpress-jquery/

> "jQuery is loaded in “no conflict” mode to prevent any potential script collisions over the $ variable in the global namespace.  As of version 3.6, WordPress will be shipping with version 1.9 of jQuery – which removes several deprecated APIs like .live().  To prevent things from breaking, WordPress automatically loads jQuery Migrate, a plugin that adds these removed APIs back to the system, but alerts you in the browser console of their deprecation."

Activating noConflict mode immediately after jQuery is enqueued and then adding the Migrate plugin should solve #117, right?

Working for me with no console errors so far.
