### PR TITLE
changes to allow child theme more flexibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,13 +14,21 @@ anything else you may wan to use plugins to keep things tidy.
 	- post and images related cleaning
 */
 require_once('lib/clean.php'); // do all the cleaning and enqueue here
-/*
-2. lib/enqueue-sass.php or enqueue-css.php
-    - enqueueing scripts & styles for Sass OR CSS
-    - please use either Sass OR CSS, having two enabled will ruin your weekend
-*/
-require_once('lib/enqueue-sass.php'); // do all the cleaning and enqueue if you Sass to customize Reverie
-//require_once('lib/enqueue-css.php'); // to use CSS for customization, uncomment this line and comment the above Sass line
+
+if(!function_exists('init_css_sass')) :
+    function init_css_sass(){
+        /*
+        2. lib/enqueue-sass.php or enqueue-css.php
+            - enqueueing scripts & styles for Sass OR CSS
+            - please use either Sass OR CSS, having two enabled will ruin your weekend
+        */
+        require_once('lib/enqueue-sass.php'); // do all the cleaning and enqueue if you Sass to customize Reverie
+        //require_once('lib/enqueue-css.php'); // to use CSS for customization, uncomment this line and comment the above Sass line
+    }
+endif;
+
+init_css_sass();
+
 /*
 3. lib/foundation.php
 	- add pagination
@@ -35,64 +43,66 @@ require_once('lib/presstrends.php'); // load PressTrends to track the usage of R
 
 /**********************
 Add theme supports
-**********************/
+ **********************/
 function reverie_theme_support() {
-	// Add language supports.
-	load_theme_textdomain('reverie', get_template_directory() . '/lang');
-	
-	// Add post thumbnail supports. http://codex.wordpress.org/Post_Thumbnails
-	add_theme_support('post-thumbnails');
-	// set_post_thumbnail_size(150, 150, false);
-	
-	// rss thingy
-	add_theme_support('automatic-feed-links');
-	
-	// Add post formarts supports. http://codex.wordpress.org/Post_Formats
-	add_theme_support('post-formats', array('aside', 'gallery', 'link', 'image', 'quote', 'status', 'video', 'audio', 'chat'));
-	
-	// Add menu supports. http://codex.wordpress.org/Function_Reference/register_nav_menus
-	add_theme_support('menus');
-	register_nav_menus(array(
-		'primary' => __('Primary Navigation', 'reverie'),
-		'utility' => __('Utility Navigation', 'reverie')
-	));
-	
-	// Add custom background support
-	add_theme_support( 'custom-background',
-	    array(
-	    'default-image' => '',  // background image default
-	    'default-color' => '', // background color default (dont add the #)
-	    'wp-head-callback' => '_custom_background_cb',
-	    'admin-head-callback' => '',
-	    'admin-preview-callback' => ''
-	    )
-	);
+    // Add language supports.
+    load_theme_textdomain('reverie', get_template_directory() . '/lang');
+
+    // Add post thumbnail supports. http://codex.wordpress.org/Post_Thumbnails
+    add_theme_support('post-thumbnails');
+    // set_post_thumbnail_size(150, 150, false);
+
+    // rss thingy
+    add_theme_support('automatic-feed-links');
+
+    // Add post formarts supports. http://codex.wordpress.org/Post_Formats
+    add_theme_support('post-formats', array('aside', 'gallery', 'link', 'image', 'quote', 'status', 'video', 'audio', 'chat'));
+
+    // Add menu supports. http://codex.wordpress.org/Function_Reference/register_nav_menus
+    add_theme_support('menus');
+    register_nav_menus(array(
+        'primary' => __('Primary Navigation', 'reverie'),
+        'utility' => __('Utility Navigation', 'reverie')
+    ));
+
+    // Add custom background support
+    add_theme_support( 'custom-background',
+        array(
+            'default-image' => '',  // background image default
+            'default-color' => '', // background color default (dont add the #)
+            'wp-head-callback' => '_custom_background_cb',
+            'admin-head-callback' => '',
+            'admin-preview-callback' => ''
+        )
+    );
 }
 add_action('after_setup_theme', 'reverie_theme_support'); /* end Reverie theme support */
 
 // create widget areas: sidebar, footer
 $sidebars = array('Sidebar');
 foreach ($sidebars as $sidebar) {
-	register_sidebar(array('name'=> $sidebar,
-		'before_widget' => '<article id="%1$s" class="row widget %2$s"><div class="small-12 columns">',
-		'after_widget' => '</div></article>',
-		'before_title' => '<h6><strong>',
-		'after_title' => '</strong></h6>'
-	));
+    register_sidebar(array('name'=> $sidebar,
+        'before_widget' => '<article id="%1$s" class="row widget %2$s"><div class="small-12 columns">',
+        'after_widget' => '</div></article>',
+        'before_title' => '<h6><strong>',
+        'after_title' => '</strong></h6>'
+    ));
 }
 $sidebars = array('Footer');
 foreach ($sidebars as $sidebar) {
-	register_sidebar(array('name'=> $sidebar,
-		'before_widget' => '<article id="%1$s" class="large-4 columns widget %2$s">',
-		'after_widget' => '</article>',
-		'before_title' => '<h6><strong>',
-		'after_title' => '</strong></h6>'
-	));
+    register_sidebar(array('name'=> $sidebar,
+        'before_widget' => '<article id="%1$s" class="large-4 columns widget %2$s">',
+        'after_widget' => '</article>',
+        'before_title' => '<h6><strong>',
+        'after_title' => '</strong></h6>'
+    ));
 }
 
 // return entry meta information for posts, used by multiple loops.
-function reverie_entry_meta() {
-	echo '<time class="updated" datetime="'. get_the_time('c') .'" pubdate>'. sprintf(__('Posted on %s at %s.', 'reverie'), get_the_time('l, F jS, Y'), get_the_time()) .'</time>';
-	echo '<p class="byline author">'. __('Written by', 'reverie') .' <a href="'. get_author_posts_url(get_the_author_meta('ID')) .'" rel="author" class="fn">'. get_the_author() .'</a></p>';
-}
+if(!function_exists('reverie_entry_meta')) :
+    function reverie_entry_meta() {
+        echo '<time class="updated" datetime="'. get_the_time('c') .'" pubdate>'. sprintf(__('Posted on %s at %s.', 'reverie'), get_the_time('l, F jS, Y'), get_the_time()) .'</time>';
+        echo '<p class="byline author">'. __('Written by', 'reverie') .' <a href="'. get_author_posts_url(get_the_author_meta('ID')) .'" rel="author" class="fn">'. get_the_author() .'</a></p>';
+    }
+endif;
 ?>


### PR DESCRIPTION
Hi,
I added changes to allow child theme to overwrite reverie_entry_meta and css/sass import. The css/sass is useful because I had to write a bash script to parse and change that line in the parent theme when doing an automated deployment. Moving this to the child should make updates easier as that wouldn't need to be changed on every update. Same goes for the reverie_entry_meta. It just makes things easier with updates.

Thanks,
Dan
