### PR TITLE
Fixed Menu Issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -513,6 +513,15 @@ footer.full-width .love-reverie {
   padding-top: 1.5rem;
 }
 
+.admin-bar > .fixed {
+  margin-top: 2rem;
+}
+
+
+.f-topbar-fixed > .container {
+  margin-top: 2rem;
+}
+
 @media only screen {
   .entry-author .avatar {
     margin-bottom: 1.25rem;


### PR DESCRIPTION
When using `contain-to-grid fixed` with the header for a sticky fixed menu two problems occur:
1. The container loses its margin due to the menu now being fixed and not relative position, this is resolved by using .f-topbar-fixed > .container {margin-top:2rem;}.
2. The other problem is only visible when logged in as admin, basically the admin bar covers the fixed menu. This can be fixed by using a margin so both bars are visible:  .admin-bar > .fixed{margin-top:2rem;}
