### PR TITLE
Proposed app.css change to fix mobile navigation drop-shadow issue

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -4806,7 +4806,7 @@ meta.foundation-mq-topbar {
 .top-bar.expanded .toggle-topbar a {
   color: #888888;
 }
-.top-bar.expanded .toggle-topbar a span {
+.top-bar.expanded .toggle-topbar.menu-icon a:after {
   -webkit-box-shadow: 0 10px 0 1px #888888, 0 16px 0 1px #888888, 0 22px 0 1px #888888;
   box-shadow: 0 10px 0 1px #888888, 0 16px 0 1px #888888, 0 22px 0 1px #888888;
 }


### PR DESCRIPTION
Changed line 4809 to [.top-bar.expanded .toggle-topbar.menu-icon a:after] to address mobile menu box-shadow issue (when menu is expanded).
