### PR TITLE
Fix typo in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ Reverie Framework is an extremely versatile HTML5 WordPress framework based on Z
 It is extremely easy to create your blog, CMS, brochure and any other kind of sites with Reverie. You can see some [samples](http://foundation.zurb.com/templates.php) on ZURB and how they make these prototypes. Did I just mention Reverie works well with [bbPress 2.0](http://bbpress.org/) and [BuddyPress 1.5](http://buddypress.org/)?
 
 ###Important###
-Please note Reverie 4 was built from groud up (almost), as well as Foundation, thus there is no easy way to upgrade from prior version. Read more about the release on [ThemeFortress](http://themefortress.com/reverie-framework-4/). And start with this version, Reverie will only support the latest and second latest WordPress. Why, [Yoast](http://yoast.com/why-we-dont-support-old-wordpress-versions/) explains it well.
+Please note Reverie 4 was built from ground up (almost), as well as Foundation, thus there is no easy way to upgrade from prior version. Read more about the release on [ThemeFortress](http://themefortress.com/reverie-framework-4/). And start with this version, Reverie will only support the latest and second latest WordPress. Why, [Yoast](http://yoast.com/why-we-dont-support-old-wordpress-versions/) explains it well.
 
 Still, if you want to get Reverie 3 (based on Foundation 3.2), you can find it at our [last Reverie 3 commit](https://github.com/milohuang/reverie/tree/2ef429776d4d3e27906e44d7d0a43cf912078e36).
 


### PR DESCRIPTION
`Fixed "built from groud" to "built from ground"`